### PR TITLE
fix: Now also generates code-behind for packages

### DIFF
--- a/Editor/Scripts/PackageSupport.cs
+++ b/Editor/Scripts/PackageSupport.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEditor.PackageManager;
+
+namespace Rosalina {
+
+	public static class PackageSupport {
+
+		private const string PACKAGES_DIRECTORY = "Packages";
+
+		private static readonly Dictionary<string, PackageSource> cache = new Dictionary<string, PackageSource>();
+
+		static PackageSupport() {
+			cache.Clear();
+			
+			var listRequest = Client.List(true, true);
+			while (!listRequest.IsCompleted) {
+				//block
+			}
+
+			foreach (var packageInfo in listRequest.Result.Where(info => info != null)) {
+				cache.Add(packageInfo.name, packageInfo.source);
+			}
+		}
+		
+		public static bool IsFileInPackage(string path) {
+			return path.StartsWith(PACKAGES_DIRECTORY);
+		}
+
+		public static bool IsPackageEmbedded(string path) {
+			var split = path.Split('/');
+			if (split[0] != PACKAGES_DIRECTORY) {
+				return false;
+			}
+
+			var packageName = split[1];
+			return GetPackageSource(packageName) == PackageSource.Embedded;
+		}
+
+		private static PackageSource GetPackageSource(string packageName) => cache[packageName];
+
+	}
+
+}

--- a/Editor/Scripts/PackageSupport.cs.meta
+++ b/Editor/Scripts/PackageSupport.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fcac15e39f3d4b159f20f982147893e4
+timeCreated: 1663051444

--- a/Editor/Scripts/RosalinaAssetProcessor.cs
+++ b/Editor/Scripts/RosalinaAssetProcessor.cs
@@ -2,7 +2,9 @@
 using System;
 using System.IO;
 using System.Linq;
+using Rosalina;
 using UnityEditor;
+using UnityEditor.PackageManager;
 using UnityEngine;
 
 public class RosalinaAssetProcessor : AssetPostprocessor
@@ -21,6 +23,14 @@ public class RosalinaAssetProcessor : AssetPostprocessor
             for (int i = 0; i < uiFilesChanged.Length; i++)
             {
                 string uiDocumentPath = uiFilesChanged[i];
+
+                if (PackageSupport.IsFileInPackage(uiDocumentPath)) {
+                    if (!PackageSupport.IsPackageEmbedded(uiDocumentPath)) {
+                        continue;
+                    }
+                }
+               
+
                 var document = new UIDocumentAsset(uiDocumentPath);
 
                 try

--- a/Editor/Scripts/RosalinaAssetProcessor.cs
+++ b/Editor/Scripts/RosalinaAssetProcessor.cs
@@ -12,7 +12,7 @@ public class RosalinaAssetProcessor : AssetPostprocessor
     private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromPath)
     {
         string[] uiFilesChanged = importedAssets
-            .Where(x => x.StartsWith("Assets"))
+            .Where(x => x.StartsWith("Assets") || x.StartsWith("Packages"))
             .Where(x => Path.GetExtension(x) == UIDocumentExtension)
             .ToArray();
 


### PR DESCRIPTION
#### Description
Now also generates code-behind for packages.

Previously everything was anything not in the "assets" folder was filtered out.