### PR TITLE
feat: General improvements 

### DIFF
--- a/Editor/Scripts/Generator/UIPropertyTypes.cs
+++ b/Editor/Scripts/Generator/UIPropertyTypes.cs
@@ -1,41 +1,17 @@
 ﻿#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine.UIElements;
 
 internal static class UIPropertyTypes
 {
-    private static readonly IReadOnlyDictionary<string, Type> _nativeUITypes = new Dictionary<string, Type>()
-    {
-        // Containers
-        { "VisualElement", typeof(UnityEngine.UIElements.VisualElement) },
-        { "ScrollView", typeof(UnityEngine.UIElements.ScrollView) },
-        { "ListView", typeof(UnityEngine.UIElements.ListView) },
-        { "IMGUIContainer", typeof(UnityEngine.UIElements.IMGUIContainer) },
-#if UNITY_2021_1_OR_NEWER
-        { "GroupBox", typeof(UnityEngine.UIElements.GroupBox) },
-#endif
-        // Controls
-        { "Label", typeof(UnityEngine.UIElements.Label) },
-        { "Button", typeof(UnityEngine.UIElements.Button) },
-        { "Toggle", typeof(UnityEngine.UIElements.Toggle) },
-        { "Scroller", typeof(UnityEngine.UIElements.Scroller) },
-        { "TextField", typeof(UnityEngine.UIElements.TextField) },
-        { "Foldout", typeof(UnityEngine.UIElements.Foldout) },
-        { "Slider", typeof(UnityEngine.UIElements.Slider) },
-        { "SliderInt", typeof(UnityEngine.UIElements.SliderInt) },
-        { "MinMaxSlider", typeof(UnityEngine.UIElements.MinMaxSlider) },
-#if UNITY_2021_1_OR_NEWER
-        { "ProgressBar", typeof(UnityEngine.UIElements.ProgressBar) },
-        { "DropdownField", typeof(UnityEngine.UIElements.DropdownField) },
-        { "RadioButton", typeof(UnityEngine.UIElements.RadioButton) },
-        { "RadioButtonGroup", typeof(UnityEngine.UIElements.RadioButtonGroup) },
-        { "Image", typeof(UnityEngine.UIElements.Image) },
-#endif
-    };
+    private static readonly List<Type> uiElementTypes = TypeCache.GetTypesDerivedFrom<ITransform>().ToList();
 
     public static Type GetUIElementType(string uiElementName)
     {
-        return _nativeUITypes.TryGetValue(uiElementName, out Type type) ? type : null;
+        return uiElementTypes.First(type => type.Name == uiElementName);
     }
 }
 #endif

--- a/Editor/Scripts/Parsing/RosalinaUXMLParser.cs
+++ b/Editor/Scripts/Parsing/RosalinaUXMLParser.cs
@@ -5,6 +5,8 @@ using System.Xml.Linq;
 internal class RosalinaUXMLParser
 {
     private const string NameAttribute = "name";
+    private const string GENERATE_CODE_BEHIND = "tactile-code-behind";
+    private const string GENERATED_NAMESPACE = "tactile-namespace";
 
     /// <summary>
     /// Parses the given UI document path.
@@ -25,6 +27,11 @@ internal class RosalinaUXMLParser
         string type = xmlNode.Name.LocalName;
         string name = xmlNode.Attribute(NameAttribute)?.Value ?? string.Empty;
         var node = new UxmlNode(type, name, xmlNode.Parent is null);
+
+        if (node.IsRoot) {
+            node.GenerateCodeBehind = xmlNode.Attribute(XName.Get(GENERATE_CODE_BEHIND)) != null;
+            node.Namespace = xmlNode.Attribute(XName.Get(GENERATED_NAMESPACE))?.Value;
+        }
 
         if (xmlNode.HasElements)
         {

--- a/Editor/Scripts/Parsing/UxmlNode.cs
+++ b/Editor/Scripts/Parsing/UxmlNode.cs
@@ -19,6 +19,16 @@ internal class UxmlNode
     /// Gets a boolean value that indicates if the current UXML node is the root node.
     /// </summary>
     public bool IsRoot { get; }
+    
+    /// <summary>
+    /// Should code behind generation take place for this UXML document.
+    /// </summary>
+    public bool GenerateCodeBehind { get; set; }
+    
+    /// <summary>
+    /// What namespace should the code behind be generated under.
+    /// </summary>
+    public string Namespace { get; set; }
 
     /// <summary>
     /// Gets the UXML child nodes.

--- a/Editor/Scripts/RosalinaAssetProcessor.cs
+++ b/Editor/Scripts/RosalinaAssetProcessor.cs
@@ -39,6 +39,10 @@ public class RosalinaAssetProcessor : AssetPostprocessor
                     Debug.Log($"[Rosalina]: Generating UI bindings for {uiDocumentPath}");
 
                     RosalinaGenerationResult result = RosalinaGenerator.GenerateBindings(document, $"{document.Name}.g.cs");
+                    if (result.Code == null) {
+                        Debug.Log($"[Rosalina]: Skipping: {document.Name}");
+                        continue;
+                    }
                     result.Save();
 
                     Debug.Log($"[Rosalina]: Done generating: {document.Name} (output: {result.OutputFilePath})");

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ UIElements Code Behind is a code generation tool for Unity's UI toolkit. It allo
 code-behind scripts based on a UXML template.
 
 ## Usage
+In your UXML, add the attribute `tactile-code-behind="true"` to the root node to enable code behind generation. 
+
+Optionally, add the attribute `tactile-namespace="MY_NAMESPACE"` to the root node to set what namespace the generated code should end up in.
+
 Create a public partial class with the same name as the UI document. Whenever the UI is about to show, call the `InitializeBinding` method in the generated partial class, and pass in the root `VisualElement` of the UI you want to show. 
 
 In order to get a hold of the root `VisualElement`, call `Instantiate` on your `VisualTreeAsset`, which is like the "prefab" for an UI document.


### PR DESCRIPTION
#### Description
Introduced 2 new root node attributes:
* `tactile-code-behind`: Only UXML documents with this attribute on the root node will have code behind generated
* `tactile-namespace`: Selects the namespace to generate the code behind in

`UIPropertyTypes` is no longer a dictionary of names->types. Instead, we cache a list of all types inheriting `ITransform` using `TypeCache`. This means all Unity and custom UIElement types will work going forwards.

#### Actions
> Any UXML with code behind already generated needs to use the new attribute in order to continue generating.