### PR TITLE
fix: Fixed compiler error due to missing meta file

### DIFF
--- a/Editor/Parsing/RosalinaUxmlParser.cs.meta
+++ b/Editor/Parsing/RosalinaUxmlParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbfbeff388cf16848b0edd7227c08ed3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
Fixed compiler error due to missing meta file.

This passed the CI due to the fact that the way Unity imports the package in the CI, leaves the package mutable. However, when real projects import this package, it's immutable. 

So in other words, the CI was allowed to generate the missing meta file and import the class. Real projects were not allowed to generate the meta file, and therefore did not import the class, causing a compiler error.