### PR TITLE
fix: Template support

### DIFF
--- a/Editor/Generator/CodeGenerator.cs
+++ b/Editor/Generator/CodeGenerator.cs
@@ -49,6 +49,9 @@ namespace TactileModules.UIElementsCodeBehind {
 		private StringBuilder GetImports(UxmlDocument uxml) {
 			var stringBuilder = new StringBuilder();
 			foreach (var @namespace in uxml.GetChildren().Select(node => node.Namespace).Distinct()) {
+				if (string.IsNullOrWhiteSpace(@namespace)) {
+					continue;
+				}
 				stringBuilder.AppendLine($"using {@namespace};");
 			}
 

--- a/Editor/Generator/UIProperty.cs
+++ b/Editor/Generator/UIProperty.cs
@@ -12,7 +12,7 @@ namespace TactileModules.UIElementsCodeBehind {
         /// <summary>
         /// Gets the UI property type name as described in the UXML file.
         /// </summary>
-        public string TypeName { get; }
+        public string TypeName => Type.Name;
 
         /// <summary>
         /// Gets the UI property type as described in the UXML file.
@@ -31,7 +31,6 @@ namespace TactileModules.UIElementsCodeBehind {
 
         public UIProperty(string type, string name)
         {
-            TypeName = type;
             Type = UIPropertyTypes.GetUIElementType(type);
             OriginalName = name;
             Name = name.Contains("-") ? name.ToPascalCase() : OriginalName;

--- a/Editor/Generator/UIPropertyTypes.cs
+++ b/Editor/Generator/UIPropertyTypes.cs
@@ -9,10 +9,14 @@ namespace TactileModules.UIElementsCodeBehind {
     internal static class UIPropertyTypes
     {
         private static readonly List<Type> uiElementTypes = TypeCache.GetTypesDerivedFrom<ITransform>().ToList();
-
-        public static Type GetUIElementType(string uiElementName)
-        {
-            return uiElementTypes.First(type => type.Name == uiElementName);
+        
+        public static Type GetUIElementType(string uiElementName) {
+            if (uiElementName == "Template" || uiElementName == "Instance") {
+                return typeof(VisualElement);
+            }
+            
+            var uiElementType = uiElementTypes.FirstOrDefault(type => type.Name == uiElementName);
+            return uiElementType ?? uiElementTypes.First(type => type.FullName == uiElementName);
         }
     }
 


### PR DESCRIPTION
#### Description
Now correctly handles cases where UXML has `Template` and `Instance` usage, by mapping those properties to `VisualElement`.